### PR TITLE
fix(actions): use canonical built CLI entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - run: pnpm format:check
       - run: pnpm web:check
       - run: pnpm build
+      - name: Smoke test built CLI
+        run: node dist/pica-library.js --help
       - name: Build Browser Lite review artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$INPUT_MODE" == 'favorites_page' ]]; then
-            node dist/library-cli.js download-favorites \
+            node dist/pica-library.js download-favorites \
               --page "$INPUT_FAVORITE_PAGE" \
               --episodes "$INPUT_EPISODES" \
               --profile "$INPUT_PROFILE" \
@@ -106,7 +106,7 @@ jobs:
             IFS=',' read -ra ids <<< "$INPUT_COMIC_IDS"
             args=()
             for id in "${ids[@]}"; do args+=("${id// /}"); done
-            node dist/library-cli.js download "${args[@]}" \
+            node dist/pica-library.js download "${args[@]}" \
               --episodes "$INPUT_EPISODES" \
               --profile "$INPUT_PROFILE" \
               --runner GITHUB \
@@ -115,7 +115,7 @@ jobs:
 
       - name: Build review artifact
         run: >-
-          node dist/library-cli.js artifact
+          node dist/pica-library.js artifact
           --output pica-download
           --data-dir .pica-library-action
 

--- a/.github/workflows/prepare-library.yml
+++ b/.github/workflows/prepare-library.yml
@@ -32,7 +32,7 @@ jobs:
       - run: pnpm build
       - name: Export favorites and recommendations
         run: >-
-          node dist/library-cli.js prepare-library
+          node dist/pica-library.js prepare-library
           --output pica-library-export
           --limit 100
           --data-dir .pica-library-action

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -17,4 +17,4 @@ pnpm build
 
 Write-Host ''
 Write-Host '配置完成。填写 .env.local 后运行：'
-Write-Host 'node dist/library-cli.js serve'
+Write-Host 'node dist/pica-library.js serve'

--- a/test/unit/workflow-entrypoint.test.ts
+++ b/test/unit/workflow-entrypoint.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = path.resolve(import.meta.dirname, '../..')
+const read = (relativePath: string) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+describe('built CLI entrypoint contract', () => {
+    it('keeps package and Rollup output aligned', () => {
+        const packageJson = JSON.parse(read('package.json')) as {
+            bin: Record<string, string>
+        }
+        const rollup = read('rollup.config.js')
+
+        expect(packageJson.bin['pica-library']).toBe('dist/pica-library.js')
+        expect(rollup).toContain("'pica-library': 'src/library-cli.ts'")
+        expect(rollup).toContain("entryFileNames: '[name].js'")
+    })
+
+    it('uses the canonical built CLI in runtime automation', () => {
+        const runtimeFiles = [
+            '.github/workflows/download.yml',
+            '.github/workflows/prepare-library.yml',
+            'scripts/setup-windows.ps1'
+        ]
+
+        for (const relativePath of runtimeFiles) {
+            const content = read(relativePath)
+            expect(content, relativePath).not.toContain('dist/library-cli.js')
+            expect(content, relativePath).toContain('dist/pica-library.js')
+        }
+
+        const downloadWorkflow = read('.github/workflows/download.yml')
+        expect(downloadWorkflow).toContain('--runner GITHUB')
+    })
+})


### PR DESCRIPTION
## Root cause

The `limited-download` workflow invoked `dist/library-cli.js`, while the Rollup build and package bin contract emit `dist/pica-library.js`.

Observed failed live run: `31617812315`.

## Scope

- Replace confirmed stale built-CLI references with `dist/pica-library.js`.
- Add a deterministic workflow entrypoint contract test.
- Smoke-test the built CLI after CI build.

No provider login, download, second live workflow run, or publication was performed. This PR must not be merged before independent ChatGPT review.