### PR TITLE
v0.3.8: allow DISCLAIMER.md in incremental update packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
             test/unit/personalization-theme-studio.test.ts \
             test/unit/update-hotfix-contract.test.ts \
             test/unit/update-manager-release-fallback.test.ts \
+            test/unit/v038-disclaimer-update-path.test.ts \
             test/unit/update-manager.test.ts
 
   android:

--- a/src/update/path-safety.ts
+++ b/src/update/path-safety.ts
@@ -5,6 +5,7 @@ const allowedRootFiles = new Set([
     'LICENSE',
     'NOTICE.md',
     'UPSTREAM.md',
+    'DISCLAIMER.md',
     'README-WINDOWS.txt',
     'README-WINDOWS.zh-CN.txt',
     'SOURCE_SHA.txt'

--- a/test/unit/v038-disclaimer-update-path.test.ts
+++ b/test/unit/v038-disclaimer-update-path.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeUpdatePath } from '../../src/update/path-safety'
+
+describe('v0.3.8 disclaimer incremental update path', () => {
+    it('allows only the explicit root disclaimer file', () => {
+        expect(normalizeUpdatePath('DISCLAIMER.md')).toBe('DISCLAIMER.md')
+        expect(() => normalizeUpdatePath('DISCLAIMER.exe')).toThrow()
+        expect(() => normalizeUpdatePath('LEGAL-NOTICE.md')).toThrow()
+        expect(() => normalizeUpdatePath('../DISCLAIMER.md')).toThrow()
+    })
+})


### PR DESCRIPTION
The first v0.3.8 release build correctly included the new root `DISCLAIMER.md`, but the incremental update path allowlist rejected that file and therefore blocked v0.3.7 -> v0.3.8 in-app updates before anything was published.

Fix:
- explicitly allow only root `DISCLAIMER.md` in `src/update/path-safety.ts`;
- keep arbitrary root files blocked;
- add a dedicated regression test covering the allowed disclaimer plus rejected executable/unknown/traversal paths;
- include the regression in normal CI.

The prior v0.3.8 publish run stopped before publication. Android signing/build passed, but the Desktop universal incremental package gate failed as designed. After this PR passes and merges, the release will be rebuilt from the new source commit and exact-tree convergence will again be required for v0.3.3 through v0.3.7.