### PR TITLE
v0.3.8: keep root disclaimer distribution-only for safe in-app upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
             test/unit/personalization-theme-studio.test.ts \
             test/unit/update-hotfix-contract.test.ts \
             test/unit/update-manager-release-fallback.test.ts \
+            test/unit/update-package-builder.test.ts \
             test/unit/v038-disclaimer-update-path.test.ts \
+            test/unit/v038-disclaimer-package-builder.test.ts \
             test/unit/update-manager.test.ts
 
   android:

--- a/scripts/build-local-update-package.ts
+++ b/scripts/build-local-update-package.ts
@@ -39,11 +39,19 @@ function sourceSha(entries: Map<string, Buffer>) {
 const registrySourceRoot = 'src/data/registry-v3-final/'
 const registryMirrorRoot = 'app/runtime-assets/registry-v3-final/'
 
+// Distribution documents may be present in a full ZIP without being part of
+// the running application tree. Existing updater helpers deliberately use a
+// narrow allowlist and must never be replaced merely to add such a document.
+// The versioned in-product disclaimer lives under web/ and remains part of the
+// incremental update; only this root documentation copy is full-install-only.
+const distributionOnlyFiles = new Set(['DISCLAIMER.md'])
+
 function incrementalChanges(
     sourceEntries: Map<string, Buffer>,
     targetEntries: Map<string, Buffer>
 ) {
     return [...targetEntries.entries()].filter(([name, value]) => {
+        if (distributionOnlyFiles.has(name)) return false
         const previous = sourceEntries.get(name)
         if (previous?.equals(value)) return false
         if (!name.startsWith(registrySourceRoot)) return true
@@ -102,7 +110,8 @@ export function buildLocalUpdatePackage(
     const targetEntries = files(new AdmZip(targetZipFile))
     const changed = incrementalChanges(sourceEntries, targetEntries)
     const deleted = [...sourceEntries.keys()].filter(
-        (name) => !targetEntries.has(name)
+        (name) =>
+            !distributionOnlyFiles.has(name) && !targetEntries.has(name)
     )
     const unsafeChanged = changed
         .map(([name]) => name)

--- a/src/update/path-safety.ts
+++ b/src/update/path-safety.ts
@@ -5,7 +5,6 @@ const allowedRootFiles = new Set([
     'LICENSE',
     'NOTICE.md',
     'UPSTREAM.md',
-    'DISCLAIMER.md',
     'README-WINDOWS.txt',
     'README-WINDOWS.zh-CN.txt',
     'SOURCE_SHA.txt'

--- a/test/unit/v038-disclaimer-package-builder.test.ts
+++ b/test/unit/v038-disclaimer-package-builder.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import AdmZip from 'adm-zip'
+import { afterEach, describe, expect, it } from 'vitest'
+import { buildLocalUpdatePackage } from '../../scripts/build-local-update-package'
+
+const directories: string[] = []
+
+function full(
+    directory: string,
+    version: string,
+    sourceSha: string,
+    entries: Record<string, string>
+) {
+    const zip = new AdmZip()
+    zip.addFile('SOURCE_SHA.txt', Buffer.from(`${sourceSha}\n`))
+    zip.addFile('app/updater.js', Buffer.from('stable-updater-helper'))
+    zip.addFile('web/app.js', Buffer.from('stable-web-app'))
+    for (const [name, value] of Object.entries(entries))
+        zip.addFile(name, Buffer.from(value))
+    const file = path.join(
+        directory,
+        `Pica-Library-v${version}-windows-x64.zip`
+    )
+    zip.writeZip(file)
+    return file
+}
+
+afterEach(() => {
+    for (const directory of directories.splice(0))
+        fs.rmSync(directory, { recursive: true, force: true })
+})
+
+describe('v0.3.8 disclaimer incremental package', () => {
+    it('ships root DISCLAIMER.md only in the full package while updating the actual web startup notice', () => {
+        const directory = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'pica-v038-disclaimer-')
+        )
+        directories.push(directory)
+        const source = full(directory, '0.3.7', '1'.repeat(40), {})
+        const target = full(directory, '0.3.8', '2'.repeat(40), {
+            'DISCLAIMER.md': 'full-package legal/readme copy',
+            'web/alpha8-disclaimer.js': 'versioned startup gate'
+        })
+        const output = path.join(directory, 'update.zip')
+        const result = buildLocalUpdatePackage(source, target, output)
+
+        expect(result.manifest.requiresFullInstall).toBe(false)
+        expect(result.manifest.files.map((item) => item.path)).toContain(
+            'web/alpha8-disclaimer.js'
+        )
+        expect(result.manifest.files.map((item) => item.path)).not.toContain(
+            'DISCLAIMER.md'
+        )
+        expect(result.manifest.files.map((item) => item.path)).not.toContain(
+            'app/updater.js'
+        )
+
+        const names = new AdmZip(output)
+            .getEntries()
+            .map((entry) => entry.entryName)
+        expect(names).toContain('web/alpha8-disclaimer.js')
+        expect(names).not.toContain('DISCLAIMER.md')
+        expect(names).not.toContain('app/updater.js')
+
+        const targetNames = new AdmZip(target)
+            .getEntries()
+            .map((entry) => entry.entryName)
+        expect(targetNames).toContain('DISCLAIMER.md')
+    })
+})

--- a/test/unit/v038-disclaimer-update-path.test.ts
+++ b/test/unit/v038-disclaimer-update-path.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { normalizeUpdatePath } from '../../src/update/path-safety'
 
-describe('v0.3.8 disclaimer incremental update path', () => {
-    it('allows only the explicit root disclaimer file', () => {
-        expect(normalizeUpdatePath('DISCLAIMER.md')).toBe('DISCLAIMER.md')
+describe('v0.3.8 disclaimer update boundary', () => {
+    it('keeps the root disclaimer outside the updater allowlist while allowing the in-product web notice', () => {
+        expect(() => normalizeUpdatePath('DISCLAIMER.md')).toThrow()
+        expect(normalizeUpdatePath('web/alpha8-disclaimer.js')).toBe(
+            'web/alpha8-disclaimer.js'
+        )
         expect(() => normalizeUpdatePath('DISCLAIMER.exe')).toThrow()
         expect(() => normalizeUpdatePath('LEGAL-NOTICE.md')).toThrow()
         expect(() => normalizeUpdatePath('../DISCLAIMER.md')).toThrow()


### PR DESCRIPTION
The second v0.3.8 release gate showed why `DISCLAIMER.md` must not be added to the updater runtime allowlist: changing that allowlist changes the bundled `app/updater.js`, and the updater correctly refuses self-replacement in an incremental package.

This patch preserves that security boundary instead of weakening it:
- reverts root `DISCLAIMER.md` from the runtime updater allowlist, restoring the updater helper bytes to the v0.3.7-compatible model;
- classifies root `DISCLAIMER.md` as full-package-only distribution documentation in `build-local-update-package.ts`;
- the actual versioned startup disclaimer remains `web/alpha8-disclaimer.js`, which is allowlisted under `web/` and therefore is delivered by in-app updates;
- adds tests proving the full ZIP may contain root `DISCLAIMER.md` while the incremental package excludes it, still includes the web startup disclaimer, and never replaces `app/updater.js`;
- restores the general update-package-builder test to the release CI selection.

No v0.3.8 release has been published yet. After this PR passes and merges, the release will be rebuilt from the new source commit and runtime-tree convergence will be verified for v0.3.3 through v0.3.7, excluding only the explicitly declared full-package-only root documentation file.