### PR TITLE
fix: make Pica registration failures actionable

### DIFF
--- a/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaAccountErrors.java
+++ b/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaAccountErrors.java
@@ -1,14 +1,53 @@
 package com.picalibrary.android;
 
-/** Allowlisted UI errors: never surface provider response bodies or headers. */
+import java.util.Locale;
+
+/** Allowlisted account diagnostics: provider response bodies are classified but never displayed. */
 final class PicaAccountErrors {
+    static String providerMarker(int status, String responseBody) {
+        if(status==429)return "PICA_ACCOUNT_RATE_LIMIT";
+        if(status>=500)return "PICA_ACCOUNT_UNAVAILABLE";
+        String value=responseBody==null?"":responseBody.toLowerCase(Locale.ROOT);
+        boolean username=containsAny(value,"email","username","user name","account");
+        boolean invalid=containsAny(value,"validation","invalid","format","length","required","missing","must be");
+        if(username && containsAny(value,"already","exist","exists","taken","registered","duplicate","duplicated"))return "PICA_ACCOUNT_USERNAME_TAKEN";
+        if(containsAny(value,"birthday","birth date","date of birth","age"))return "PICA_ACCOUNT_INVALID_BIRTHDAY";
+        if(username && invalid)return "PICA_ACCOUNT_INVALID_USERNAME";
+        if(containsAny(value,"password","passwd") && invalid)return "PICA_ACCOUNT_INVALID_PASSWORD";
+        if(containsAny(value,"nickname","display name") && invalid)return "PICA_ACCOUNT_INVALID_NICKNAME";
+        if(containsAny(value,"question","answer","security","recovery") && invalid)return "PICA_ACCOUNT_INVALID_RECOVERY";
+        if(value.contains("1002") || invalid)return "PICA_ACCOUNT_VALIDATION";
+        if(status==409)return "PICA_ACCOUNT_USERNAME_TAKEN";
+        return "PICA_ACCOUNT_REJECTED";
+    }
+
     static String message(Exception error) {
-        if(error instanceof java.net.SocketTimeoutException || error instanceof java.net.ConnectException || error instanceof java.net.UnknownHostException || error instanceof javax.net.ssl.SSLException)
-            return "无法连接 Pica，请检查网络或设备代理，不要反复修改密码。";
+        if(isNetwork(error))
+            return "无法连接 Pica API。注册本身不强制使用代理，但当前网络直连失败；请开启系统代理或加速器后重试。";
         String value=error.getMessage();
-        if("PICA_ACCOUNT_RATE_LIMIT".equals(value))return "Pica 请求过于频繁，请稍后再试。";
-        if("PICA_ACCOUNT_REJECTED".equals(value))return "Pica 拒绝了账号请求，请检查填写信息或使用 Pica 客户端确认账号状态。";
-        if("PICA_ACCOUNT_UNAVAILABLE".equals(value))return "Pica 账号服务暂时不可用。";
-        return "账号请求未能确认，请检查网络或稍后再试。";
+        if("PICA_ACCOUNT_USERNAME_TAKEN".equals(value))return "该用户名已被注册。请更换用户名；如果刚刚提交过注册，请先尝试登录确认账号是否已创建。";
+        if("PICA_ACCOUNT_INVALID_USERNAME".equals(value))return "用户名未被 Pica 接受。请使用 1–16 位字母、数字、点或下划线。";
+        if("PICA_ACCOUNT_INVALID_PASSWORD".equals(value))return "密码未被 Pica 接受。请使用至少 8 个字符的密码。";
+        if("PICA_ACCOUNT_INVALID_BIRTHDAY".equals(value))return "出生日期未被 Pica 接受。请使用 YYYY-MM-DD 的有效日期，并确认已年满 18 岁。";
+        if("PICA_ACCOUNT_INVALID_NICKNAME".equals(value))return "昵称未被 Pica 接受。请使用 2–50 个字符的昵称。";
+        if("PICA_ACCOUNT_INVALID_RECOVERY".equals(value))return "安全问题或答案未被 Pica 接受。请完整填写 3 组安全问题和答案。";
+        if("PICA_ACCOUNT_VALIDATION".equals(value))return "Pica 未接受部分注册资料。请检查用户名、昵称、生日、密码和 3 组安全问题/答案。";
+        if("PICA_ACCOUNT_RATE_LIMIT".equals(value))return "Pica 请求过于频繁，请稍后再试，不要连续重复提交。";
+        if("PICA_ACCOUNT_REJECTED".equals(value))return "Pica 拒绝了账号请求，但未返回可安全识别的具体原因。请检查填写信息后重试。";
+        if("PICA_ACCOUNT_UNAVAILABLE".equals(value))return "Pica 账号服务暂时不可用，请稍后再试。";
+        if("PICA_ACCOUNT_RESPONSE_INVALID".equals(value))return "Pica 返回了无法识别的账号响应，结果尚未确认。请先尝试登录，不要重复注册。";
+        return "账号请求未能确认。请先检查网络；如果刚提交过注册，请先尝试登录，不要立即重复创建。";
+    }
+
+    private static boolean isNetwork(Throwable error) {
+        for(Throwable current=error;current!=null;current=current.getCause()) {
+            if(current instanceof java.net.SocketTimeoutException || current instanceof java.net.ConnectException || current instanceof java.net.UnknownHostException || current instanceof javax.net.ssl.SSLException)return true;
+        }
+        return false;
+    }
+
+    private static boolean containsAny(String value,String... needles) {
+        for(String needle:needles)if(value.contains(needle))return true;
+        return false;
     }
 }

--- a/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaAccountErrors.java
+++ b/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaAccountErrors.java
@@ -23,7 +23,7 @@ final class PicaAccountErrors {
 
     static String message(Exception error) {
         if(isNetwork(error))
-            return "无法连接 Pica API。注册本身不强制使用代理，但当前网络直连失败；请开启系统代理或加速器后重试。";
+            return "无法连接 Pica API。注册本身不强制使用代理，但当前网络直连失败；请开启系统代理或加速器后重试。若请求在提交途中断开，请先尝试登录。";
         String value=error.getMessage();
         if("PICA_ACCOUNT_USERNAME_TAKEN".equals(value))return "该用户名已被注册。请更换用户名；如果刚刚提交过注册，请先尝试登录确认账号是否已创建。";
         if("PICA_ACCOUNT_INVALID_USERNAME".equals(value))return "用户名未被 Pica 接受。请使用 1–16 位字母、数字、点或下划线。";
@@ -33,10 +33,16 @@ final class PicaAccountErrors {
         if("PICA_ACCOUNT_INVALID_RECOVERY".equals(value))return "安全问题或答案未被 Pica 接受。请完整填写 3 组安全问题和答案。";
         if("PICA_ACCOUNT_VALIDATION".equals(value))return "Pica 未接受部分注册资料。请检查用户名、昵称、生日、密码和 3 组安全问题/答案。";
         if("PICA_ACCOUNT_RATE_LIMIT".equals(value))return "Pica 请求过于频繁，请稍后再试，不要连续重复提交。";
-        if("PICA_ACCOUNT_REJECTED".equals(value))return "Pica 拒绝了账号请求，但未返回可安全识别的具体原因。请检查填写信息后重试。";
+        if("PICA_ACCOUNT_REJECTED".equals(value))return "Pica 已拒绝本次注册请求。常见原因是用户名已存在或资料未通过服务端校验；请先检查用户名、生日和其他必填项。";
         if("PICA_ACCOUNT_UNAVAILABLE".equals(value))return "Pica 账号服务暂时不可用，请稍后再试。";
         if("PICA_ACCOUNT_RESPONSE_INVALID".equals(value))return "Pica 返回了无法识别的账号响应，结果尚未确认。请先尝试登录，不要重复注册。";
         return "账号请求未能确认。请先检查网络；如果刚提交过注册，请先尝试登录，不要立即重复创建。";
+    }
+
+    static boolean retrySafe(Exception error) {
+        if(isNetwork(error))return false;
+        String value=error.getMessage();
+        return !"PICA_ACCOUNT_RESPONSE_INVALID".equals(value);
     }
 
     private static boolean isNetwork(Throwable error) {

--- a/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaAccountErrors.java
+++ b/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaAccountErrors.java
@@ -1,39 +1,13 @@
 package com.picalibrary.android;
 
-import java.util.Locale;
-
-/** Allowlisted account diagnostics: provider response bodies are classified but never displayed. */
+/** Allowlisted account diagnostics. Never surface provider response bodies or headers. */
 final class PicaAccountErrors {
-    static String providerMarker(int status, String responseBody) {
-        if(status==429)return "PICA_ACCOUNT_RATE_LIMIT";
-        if(status>=500)return "PICA_ACCOUNT_UNAVAILABLE";
-        String value=responseBody==null?"":responseBody.toLowerCase(Locale.ROOT);
-        boolean username=containsAny(value,"email","username","user name","account");
-        boolean invalid=containsAny(value,"validation","invalid","format","length","required","missing","must be");
-        if(username && containsAny(value,"already","exist","exists","taken","registered","duplicate","duplicated"))return "PICA_ACCOUNT_USERNAME_TAKEN";
-        if(containsAny(value,"birthday","birth date","date of birth","age"))return "PICA_ACCOUNT_INVALID_BIRTHDAY";
-        if(username && invalid)return "PICA_ACCOUNT_INVALID_USERNAME";
-        if(containsAny(value,"password","passwd") && invalid)return "PICA_ACCOUNT_INVALID_PASSWORD";
-        if(containsAny(value,"nickname","display name") && invalid)return "PICA_ACCOUNT_INVALID_NICKNAME";
-        if(containsAny(value,"question","answer","security","recovery") && invalid)return "PICA_ACCOUNT_INVALID_RECOVERY";
-        if(value.contains("1002") || invalid)return "PICA_ACCOUNT_VALIDATION";
-        if(status==409)return "PICA_ACCOUNT_USERNAME_TAKEN";
-        return "PICA_ACCOUNT_REJECTED";
-    }
-
     static String message(Exception error) {
         if(isNetwork(error))
             return "无法连接 Pica API。注册本身不强制使用代理，但当前网络直连失败；请开启系统代理或加速器后重试。若请求在提交途中断开，请先尝试登录。";
         String value=error.getMessage();
-        if("PICA_ACCOUNT_USERNAME_TAKEN".equals(value))return "该用户名已被注册。请更换用户名；如果刚刚提交过注册，请先尝试登录确认账号是否已创建。";
-        if("PICA_ACCOUNT_INVALID_USERNAME".equals(value))return "用户名未被 Pica 接受。请使用 1–16 位字母、数字、点或下划线。";
-        if("PICA_ACCOUNT_INVALID_PASSWORD".equals(value))return "密码未被 Pica 接受。请使用至少 8 个字符的密码。";
-        if("PICA_ACCOUNT_INVALID_BIRTHDAY".equals(value))return "出生日期未被 Pica 接受。请使用 YYYY-MM-DD 的有效日期，并确认已年满 18 岁。";
-        if("PICA_ACCOUNT_INVALID_NICKNAME".equals(value))return "昵称未被 Pica 接受。请使用 2–50 个字符的昵称。";
-        if("PICA_ACCOUNT_INVALID_RECOVERY".equals(value))return "安全问题或答案未被 Pica 接受。请完整填写 3 组安全问题和答案。";
-        if("PICA_ACCOUNT_VALIDATION".equals(value))return "Pica 未接受部分注册资料。请检查用户名、昵称、生日、密码和 3 组安全问题/答案。";
         if("PICA_ACCOUNT_RATE_LIMIT".equals(value))return "Pica 请求过于频繁，请稍后再试，不要连续重复提交。";
-        if("PICA_ACCOUNT_REJECTED".equals(value))return "Pica 已拒绝本次注册请求。常见原因是用户名已存在或资料未通过服务端校验；请先检查用户名、生日和其他必填项。";
+        if("PICA_ACCOUNT_REJECTED".equals(value))return "Pica 已拒绝本次注册请求。请检查用户名、昵称、生日、密码以及 3 组安全问题和答案后重试。";
         if("PICA_ACCOUNT_UNAVAILABLE".equals(value))return "Pica 账号服务暂时不可用，请稍后再试。";
         if("PICA_ACCOUNT_RESPONSE_INVALID".equals(value))return "Pica 返回了无法识别的账号响应，结果尚未确认。请先尝试登录，不要重复注册。";
         return "账号请求未能确认。请先检查网络；如果刚提交过注册，请先尝试登录，不要立即重复创建。";
@@ -42,18 +16,15 @@ final class PicaAccountErrors {
     static boolean retrySafe(Exception error) {
         if(isNetwork(error))return false;
         String value=error.getMessage();
-        return !"PICA_ACCOUNT_RESPONSE_INVALID".equals(value);
+        return "PICA_ACCOUNT_REJECTED".equals(value)
+                || "PICA_ACCOUNT_RATE_LIMIT".equals(value)
+                || "PICA_ACCOUNT_UNAVAILABLE".equals(value);
     }
 
     private static boolean isNetwork(Throwable error) {
         for(Throwable current=error;current!=null;current=current.getCause()) {
             if(current instanceof java.net.SocketTimeoutException || current instanceof java.net.ConnectException || current instanceof java.net.UnknownHostException || current instanceof javax.net.ssl.SSLException)return true;
         }
-        return false;
-    }
-
-    private static boolean containsAny(String value,String... needles) {
-        for(String needle:needles)if(value.contains(needle))return true;
         return false;
     }
 }

--- a/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaRegisterActivity.java
+++ b/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaRegisterActivity.java
@@ -34,7 +34,7 @@ public final class PicaRegisterActivity extends Activity {
         content.addView(Ui.text(this,"这是第三方哔咔账号，不是 GitHub 账号。手机独立连接 Pica，无需电脑。注册本身不强制使用代理；如果提示无法连接 Pica API，说明当前网络直连失败，请开启系统代理或加速器后重试。",14,Ui.MUTED,false));
         field(content,"name","昵称（2–50 字）",false);
         field(content,"email","用户名（1–16 位字母 / 数字 / . / _）",false);
-        field(content,"password","密码（至少 8 位）",true);
+        field(content,"password","密码（至少 9 位）",true);
         field(content,"confirmPassword","确认密码",true);
         field(content,"birthday","出生日期（YYYY-MM-DD，年满 18 岁）",false);
         gender = new Spinner(this);

--- a/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaRegisterActivity.java
+++ b/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaRegisterActivity.java
@@ -31,10 +31,10 @@ public final class PicaRegisterActivity extends Activity {
         back = Ui.button(this,"‹ 返回登录",v->finish(),true);
         content.addView(back);
         content.addView(Ui.text(this,"注册 Pica 账号",24,Ui.TEXT,true));
-        content.addView(Ui.text(this,"这是第三方哔咔账号，不是 GitHub 账号。手机独立连接 Pica，无需电脑。请使用真实出生日期，并自行妥善保管安全答案。",14,Ui.MUTED,false));
+        content.addView(Ui.text(this,"这是第三方哔咔账号，不是 GitHub 账号。手机独立连接 Pica，无需电脑。注册本身不强制使用代理；如果提示无法连接 Pica API，说明当前网络直连失败，请开启系统代理或加速器后重试。",14,Ui.MUTED,false));
         field(content,"name","昵称（2–50 字）",false);
-        field(content,"email","新账号标识",false);
-        field(content,"password","密码（至少 9 位）",true);
+        field(content,"email","用户名（1–16 位字母 / 数字 / . / _）",false);
+        field(content,"password","密码（至少 8 位）",true);
         field(content,"confirmPassword","确认密码",true);
         field(content,"birthday","出生日期（YYYY-MM-DD，年满 18 岁）",false);
         gender = new Spinner(this);
@@ -45,7 +45,7 @@ public final class PicaRegisterActivity extends Activity {
         consent.setText("我已年满 18 岁，了解并将遵守第三方 Pica 服务条款，仅访问合法授权内容。注册资料发送至 Pica，Pica Library 不保存安全答案。");
         consent.setTextColor(Ui.TEXT);
         content.addView(consent);
-        status = Ui.text(this,"注册成功后请返回登录；不会自动同步或下载。",13,Ui.MUTED,false);
+        status = Ui.text(this,"注册成功后请返回登录；失败时会保留当前表单，方便按具体原因修改。",13,Ui.MUTED,false);
         content.addView(status);
         submit = Ui.button(this,"确认并注册",v->register(),false);
         content.addView(submit);
@@ -70,7 +70,7 @@ public final class PicaRegisterActivity extends Activity {
         input.put("gender",new String[]{"","m","f","bot"}[gender.getSelectedItemPosition()]);
         final Map<String,String> payload;
         try { payload=PicaRegistrationInput.validate(input,consent.isChecked(),LocalDate.now(java.time.ZoneOffset.UTC)); }
-        catch(IllegalArgumentException error) { status.setText(error.getMessage()); return; }
+        catch(IllegalArgumentException error) { status.setText("注册失败："+error.getMessage()); return; }
         input.clear();
         busy=true;
         submit.setEnabled(false);
@@ -78,11 +78,31 @@ public final class PicaRegisterActivity extends Activity {
         status.setText("正在提交，请勿重复注册…");
         new Thread(()->{
             String message;
-            try { new PicaClient(this).register(payload); message="注册成功。请返回登录并输入新账号和密码。"; }
-            catch(Exception error) { message="注册未确认："+PicaAccountErrors.message(error)+" 若连接中断，账号可能已创建，请先尝试登录。"; }
-            finally { payload.clear(); }
+            boolean success=false;
+            boolean retrySafe=false;
+            try {
+                new PicaClient(this).register(payload);
+                success=true;
+                message="注册成功。请返回登录并输入新账号和密码。";
+            } catch(Exception error) {
+                retrySafe=PicaAccountErrors.retrySafe(error);
+                message="注册失败："+PicaAccountErrors.message(error)+(retrySafe?" 当前表单已保留，可修改后重新提交。":" 本次结果可能无法确认，请先返回登录尝试，不要立即重复注册。");
+            } finally { payload.clear(); }
             final String result=message;
-            runOnUiThread(()->{busy=false;back.setEnabled(true);status.setText(result);for(EditText field:fields.values())field.setText("");});
+            final boolean registered=success;
+            final boolean canRetry=retrySafe;
+            runOnUiThread(()->{
+                busy=false;
+                back.setEnabled(true);
+                status.setText(result);
+                if(registered) {
+                    for(EditText field:fields.values())field.setText("");
+                    gender.setSelection(0);
+                    consent.setChecked(false);
+                } else if(canRetry) {
+                    submit.setEnabled(true);
+                }
+            });
         },"pica-registration").start();
     }
     @Override public void onBackPressed() { if(!busy)super.onBackPressed(); }

--- a/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaRegistrationInput.java
+++ b/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaRegistrationInput.java
@@ -4,15 +4,20 @@ import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /** Pure validation. Passwords and answers are never normalized or persisted. */
 final class PicaRegistrationInput {
+    private static final Pattern NEW_USERNAME = Pattern.compile("^[A-Za-z0-9._]{1,16}$");
+
     static Map<String,String> validate(Map<String,String> input, boolean accepted, LocalDate today) {
         if (!accepted) throw new IllegalArgumentException("请确认年龄要求和第三方服务说明");
         Map<String,String> out = new LinkedHashMap<>();
         out.put("name", value(input,"name",2,50,true));
-        out.put("email", value(input,"email",1,254,true));
-        String password = value(input,"password",9,128,false);
+        String username = value(input,"email",1,16,true);
+        if(!NEW_USERNAME.matcher(username).matches()) throw new IllegalArgumentException("用户名应为 1–16 位字母、数字、点或下划线");
+        out.put("email", username);
+        String password = value(input,"password",8,128,false);
         if (!password.equals(input.get("confirmPassword"))) throw new IllegalArgumentException("两次密码不一致");
         out.put("password",password);
         String birthday = value(input,"birthday",10,10,true);

--- a/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaRegistrationInput.java
+++ b/mobile/android-alpha2/app/src/main/java/com/picalibrary/android/PicaRegistrationInput.java
@@ -17,7 +17,7 @@ final class PicaRegistrationInput {
         String username = value(input,"email",1,16,true);
         if(!NEW_USERNAME.matcher(username).matches()) throw new IllegalArgumentException("用户名应为 1–16 位字母、数字、点或下划线");
         out.put("email", username);
-        String password = value(input,"password",8,128,false);
+        String password = value(input,"password",9,128,false);
         if (!password.equals(input.get("confirmPassword"))) throw new IllegalArgumentException("两次密码不一致");
         out.put("password",password);
         String birthday = value(input,"birthday",10,10,true);

--- a/mobile/android-alpha2/app/src/test/java/com/picalibrary/android/PicaRegistrationInputTest.java
+++ b/mobile/android-alpha2/app/src/test/java/com/picalibrary/android/PicaRegistrationInputTest.java
@@ -24,13 +24,13 @@ public class PicaRegistrationInputTest {
         assertFalse(out.containsKey("confirmPassword"));
         assertEquals(11, out.size());
     }
-    @Test public void newUsernameAndPasswordRulesMatchProviderClients() {
+    @Test public void newUsernameAndPasswordRulesStayConservative() {
         Map<String,String> valid = fixture();
-        valid.put("email", "reader.01_"); valid.put("password", "12345678"); valid.put("confirmPassword", "12345678");
+        valid.put("email", "reader.01_"); valid.put("password", "123456789"); valid.put("confirmPassword", "123456789");
         assertEquals("reader.01_", PicaRegistrationInput.validate(valid, true, LocalDate.of(2026,9,13)).get("email"));
 
         Map<String,String> tooShort = fixture();
-        tooShort.put("password", "1234567"); tooShort.put("confirmPassword", "1234567");
+        tooShort.put("password", "12345678"); tooShort.put("confirmPassword", "12345678");
         assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(tooShort, true, LocalDate.of(2026,9,13)));
 
         Map<String,String> invalidSymbol = fixture();
@@ -60,13 +60,13 @@ public class PicaRegistrationInputTest {
         input.put("birthday", "2000-02-29"); input.put("answer1", "bad\nanswer");
         assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(input, true, LocalDate.now()));
     }
-    @Test public void classifiesKnownProviderFailuresWithoutShowingBodies() {
-        assertEquals("PICA_ACCOUNT_USERNAME_TAKEN", PicaAccountErrors.providerMarker(400, "email already exists sensitive-value"));
-        assertEquals("PICA_ACCOUNT_INVALID_BIRTHDAY", PicaAccountErrors.providerMarker(400, "error 1002 validation error: birthday must be a valid date string"));
+    @Test public void keepsAccountErrorsSafeAndRetryAware() {
         assertFalse(PicaAccountErrors.message(new Exception("token=fixture-sensitive-body")).contains("fixture-sensitive"));
         assertTrue(PicaAccountErrors.message(new java.net.SocketTimeoutException()).contains("直连失败"));
         assertTrue(PicaAccountErrors.message(new Exception("PICA_ACCOUNT_REJECTED")).contains("拒绝"));
         assertFalse(PicaAccountErrors.retrySafe(new java.net.SocketTimeoutException()));
+        assertFalse(PicaAccountErrors.retrySafe(new Exception("PICA_ACCOUNT_RESPONSE_INVALID")));
+        assertFalse(PicaAccountErrors.retrySafe(new Exception("unknown")));
         assertTrue(PicaAccountErrors.retrySafe(new Exception("PICA_ACCOUNT_REJECTED")));
     }
 }

--- a/mobile/android-alpha2/app/src/test/java/com/picalibrary/android/PicaRegistrationInputTest.java
+++ b/mobile/android-alpha2/app/src/test/java/com/picalibrary/android/PicaRegistrationInputTest.java
@@ -9,20 +9,33 @@ import static org.junit.Assert.*;
 public class PicaRegistrationInputTest {
     private Map<String,String> fixture() {
         Map<String,String> input = new LinkedHashMap<>();
-        input.put("name", " Demo "); input.put("email", "demo-identifier");
+        input.put("name", " Demo "); input.put("email", "demo_reader");
         input.put("password", " fixture-password "); input.put("confirmPassword", " fixture-password ");
         input.put("birthday", "2000-02-29"); input.put("gender", "bot");
         for (int i = 1; i <= 3; i++) { input.put("question"+i, " Demo question "); input.put("answer"+i, " answer "); }
         return input;
     }
-    @Test public void acceptsAccountIdentifierWithoutAtAndPreservesSecrets() {
+    @Test public void acceptsUsernameWithoutAtAndPreservesSecrets() {
         Map<String,String> out = PicaRegistrationInput.validate(fixture(), true, LocalDate.of(2026, 9, 13));
-        assertEquals("demo-identifier", out.get("email"));
+        assertEquals("demo_reader", out.get("email"));
         assertEquals("Demo", out.get("name"));
         assertEquals(" fixture-password ", out.get("password"));
         assertEquals(" answer ", out.get("answer1"));
         assertFalse(out.containsKey("confirmPassword"));
         assertEquals(11, out.size());
+    }
+    @Test public void newUsernameAndPasswordRulesMatchProviderClients() {
+        Map<String,String> input = fixture();
+        input.put("email", "reader.01_"); input.put("password", "12345678"); input.put("confirmPassword", "12345678");
+        assertEquals("reader.01_", PicaRegistrationInput.validate(input, true, LocalDate.of(2026,9,13)).get("email"));
+        input.put("password", "1234567"); input.put("confirmPassword", "1234567");
+        assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(input, true, LocalDate.of(2026,9,13)));
+        input = fixture(); input.put("email", "reader-name");
+        Map<String,String> invalidSymbol = input;
+        assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(invalidSymbol, true, LocalDate.of(2026,9,13)));
+        input = fixture(); input.put("email", "12345678901234567");
+        Map<String,String> tooLong = input;
+        assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(tooLong, true, LocalDate.of(2026,9,13)));
     }
     @Test public void rejectsMissingConsent() {
         assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(fixture(), false, LocalDate.now()));
@@ -43,9 +56,13 @@ public class PicaRegistrationInputTest {
         input.put("birthday", "2000-02-29"); input.put("answer1", "bad\nanswer");
         assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(input, true, LocalDate.now()));
     }
-    @Test public void neverShowsUntrustedProviderBodies() {
+    @Test public void classifiesKnownProviderFailuresWithoutShowingBodies() {
+        assertEquals("PICA_ACCOUNT_USERNAME_TAKEN", PicaAccountErrors.providerMarker(400, "email already exists sensitive-value"));
+        assertEquals("PICA_ACCOUNT_INVALID_BIRTHDAY", PicaAccountErrors.providerMarker(400, "error 1002 validation error: birthday must be a valid date string"));
         assertFalse(PicaAccountErrors.message(new Exception("token=fixture-sensitive-body")).contains("fixture-sensitive"));
-        assertTrue(PicaAccountErrors.message(new java.net.SocketTimeoutException()).contains("网络"));
+        assertTrue(PicaAccountErrors.message(new java.net.SocketTimeoutException()).contains("直连失败"));
         assertTrue(PicaAccountErrors.message(new Exception("PICA_ACCOUNT_REJECTED")).contains("拒绝"));
+        assertFalse(PicaAccountErrors.retrySafe(new java.net.SocketTimeoutException()));
+        assertTrue(PicaAccountErrors.retrySafe(new Exception("PICA_ACCOUNT_REJECTED")));
     }
 }

--- a/mobile/android-alpha2/app/src/test/java/com/picalibrary/android/PicaRegistrationInputTest.java
+++ b/mobile/android-alpha2/app/src/test/java/com/picalibrary/android/PicaRegistrationInputTest.java
@@ -25,16 +25,20 @@ public class PicaRegistrationInputTest {
         assertEquals(11, out.size());
     }
     @Test public void newUsernameAndPasswordRulesMatchProviderClients() {
-        Map<String,String> input = fixture();
-        input.put("email", "reader.01_"); input.put("password", "12345678"); input.put("confirmPassword", "12345678");
-        assertEquals("reader.01_", PicaRegistrationInput.validate(input, true, LocalDate.of(2026,9,13)).get("email"));
-        input.put("password", "1234567"); input.put("confirmPassword", "1234567");
-        assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(input, true, LocalDate.of(2026,9,13)));
-        input = fixture(); input.put("email", "reader-name");
-        Map<String,String> invalidSymbol = input;
+        Map<String,String> valid = fixture();
+        valid.put("email", "reader.01_"); valid.put("password", "12345678"); valid.put("confirmPassword", "12345678");
+        assertEquals("reader.01_", PicaRegistrationInput.validate(valid, true, LocalDate.of(2026,9,13)).get("email"));
+
+        Map<String,String> tooShort = fixture();
+        tooShort.put("password", "1234567"); tooShort.put("confirmPassword", "1234567");
+        assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(tooShort, true, LocalDate.of(2026,9,13)));
+
+        Map<String,String> invalidSymbol = fixture();
+        invalidSymbol.put("email", "reader-name");
         assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(invalidSymbol, true, LocalDate.of(2026,9,13)));
-        input = fixture(); input.put("email", "12345678901234567");
-        Map<String,String> tooLong = input;
+
+        Map<String,String> tooLong = fixture();
+        tooLong.put("email", "12345678901234567");
         assertThrows(IllegalArgumentException.class, () -> PicaRegistrationInput.validate(tooLong, true, LocalDate.of(2026,9,13)));
     }
     @Test public void rejectsMissingConsent() {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -91,8 +91,11 @@ export class Pica {
 
                 // Account responses can echo secrets even on rejection: never log them.
                 if (url === 'auth/sign-in' || url === 'auth/register') {
-                    if (!result || result.code !== 200)
-                        throw new PicaAccountError('REJECTED', res.status)
+                    if (!result || result.code !== 200) {
+                        const action = url === 'auth/register' ? 'register' : 'login'
+                        const status = Number(result?.code) || res.status
+                        throw accountHttpError(status, result, action)
+                    }
                     return result.data ?? {}
                 }
 
@@ -111,8 +114,12 @@ export class Pica {
             (error: AxiosError) => {
                 const { config, message, response } = error
 
-                if (config?.url === 'auth/sign-in' || config?.url === 'auth/register')
-                    return Promise.reject(accountHttpError(response?.status))
+                if (config?.url === 'auth/sign-in' || config?.url === 'auth/register') {
+                    const action = config.url === 'auth/register' ? 'register' : 'login'
+                    return Promise.reject(
+                        accountHttpError(response?.status, response?.data, action)
+                    )
+                }
 
                 // 哔咔禁止访问的资源
                 if (response?.status === 400) {
@@ -176,7 +183,7 @@ export class Pica {
         order = this.Order.default,
         page = 1
     ) {
-        const res = await this.comics(block, tag, order, page)
+        const res = await this.comicsPage(block, tag, order, page)
         return res.comics as PageSearch
     }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -183,7 +183,7 @@ export class Pica {
         order = this.Order.default,
         page = 1
     ) {
-        const res = await this.comicsPage(block, tag, order, page)
+        const res = await this.comics(block, tag, order, page)
         return res.comics as PageSearch
     }
 

--- a/src/services/pica-account.ts
+++ b/src/services/pica-account.ts
@@ -51,7 +51,7 @@ export function validatePicaRegistration(
     const username = text('email', 1, 16)
     if (!NEW_USERNAME.test(username))
         throw new Error('用户名应为 1–16 位字母、数字、点或下划线')
-    const password = text('password', 8, 128, false)
+    const password = text('password', 9, 128, false)
     if (input.confirmPassword !== password)
         throw new Error('两次输入的密码不一致')
     return {
@@ -92,7 +92,7 @@ const accountMessages: Record<PicaAccountCategory, string> = {
     INVALID_USERNAME:
         '用户名未被 Pica 接受。新用户名请使用 1–16 位字母、数字、点或下划线。',
     INVALID_PASSWORD:
-        '密码未被 Pica 接受。请使用至少 8 个字符的密码，并确认两次输入完全一致。',
+        '密码未被 Pica 接受。请使用至少 9 个字符的密码，并确认两次输入完全一致。',
     INVALID_BIRTHDAY:
         '出生日期未被 Pica 接受。请使用 YYYY-MM-DD 的有效日期，并确认已年满 18 岁。',
     INVALID_NICKNAME:

--- a/src/services/pica-account.ts
+++ b/src/services/pica-account.ts
@@ -13,6 +13,8 @@ export interface PicaRegistration {
     answer3: string
 }
 
+const NEW_USERNAME = /^[A-Za-z0-9._]{1,16}$/
+
 export function validatePicaRegistration(
     input: Record<string, unknown>,
     now = new Date()
@@ -37,7 +39,7 @@ export function validatePicaRegistration(
         !Number.isFinite(date.getTime()) ||
         date.toISOString().slice(0, 10) !== birthday
     )
-        throw new Error('请填写有效的出生日期')
+        throw new Error('请填写有效的出生日期（YYYY-MM-DD）')
     const today = now.toISOString().slice(0, 10)
     const age =
         Number(today.slice(0, 4)) -
@@ -46,13 +48,16 @@ export function validatePicaRegistration(
     if (age < 18) throw new Error('此服务仅限年满 18 岁的用户注册')
     if (!['m', 'f', 'bot'].includes(String(input.gender)))
         throw new Error('请选择性别选项')
-    const password = text('password', 9, 128, false)
+    const username = text('email', 1, 16)
+    if (!NEW_USERNAME.test(username))
+        throw new Error('用户名应为 1–16 位字母、数字、点或下划线')
+    const password = text('password', 8, 128, false)
     if (input.confirmPassword !== password)
         throw new Error('两次输入的密码不一致')
     return {
         name: text('name', 2, 50),
-        // The provider calls this field email; existing identifiers need not contain @.
-        email: text('email', 1, 254),
+        // The provider calls the username field `email`; it is not required to be an email address.
+        email: username,
         password,
         birthday,
         gender: input.gender as PicaRegistration['gender'],
@@ -65,34 +70,110 @@ export function validatePicaRegistration(
     }
 }
 
+export type PicaAccountCategory =
+    | 'NETWORK'
+    | 'USERNAME_TAKEN'
+    | 'INVALID_USERNAME'
+    | 'INVALID_PASSWORD'
+    | 'INVALID_BIRTHDAY'
+    | 'INVALID_NICKNAME'
+    | 'INVALID_RECOVERY'
+    | 'VALIDATION'
+    | 'RATE_LIMIT'
+    | 'UNAVAILABLE'
+    | 'REJECTED'
+    | 'RESPONSE'
+
+const accountMessages: Record<PicaAccountCategory, string> = {
+    NETWORK:
+        '无法连接 Pica API。注册本身不强制使用代理，但当前网络未能连通；请开启系统代理/加速器或配置 HTTP/HTTPS 代理后再试。',
+    USERNAME_TAKEN:
+        '该用户名已被注册。请更换用户名；如果你刚刚提交过一次注册，请先返回登录确认账号是否已经创建。',
+    INVALID_USERNAME:
+        '用户名未被 Pica 接受。新用户名请使用 1–16 位字母、数字、点或下划线。',
+    INVALID_PASSWORD:
+        '密码未被 Pica 接受。请使用至少 8 个字符的密码，并确认两次输入完全一致。',
+    INVALID_BIRTHDAY:
+        '出生日期未被 Pica 接受。请使用 YYYY-MM-DD 的有效日期，并确认已年满 18 岁。',
+    INVALID_NICKNAME:
+        '昵称未被 Pica 接受。请使用 2–50 个字符的昵称后重试。',
+    INVALID_RECOVERY:
+        '安全问题或答案未被 Pica 接受。请完整填写 3 组安全问题和答案。',
+    VALIDATION:
+        'Pica 未接受部分注册资料。请检查用户名、昵称、生日、密码和 3 组安全问题/答案。',
+    RATE_LIMIT: 'Pica 请求过于频繁，请稍后再试，不要连续重复提交。',
+    UNAVAILABLE: 'Pica 账号服务暂时不可用，请稍后再试。',
+    REJECTED:
+        'Pica 拒绝了账号请求，但未返回可安全识别的具体原因。请检查填写信息后重试。',
+    RESPONSE:
+        'Pica 账号响应异常，结果尚未确认。请先尝试登录，不要重复注册。'
+}
+
 export class PicaAccountError extends Error {
     constructor(
-        readonly category: string,
+        readonly category: PicaAccountCategory,
         readonly httpStatus?: number
     ) {
-        const messages: Record<string, string> = {
-            NETWORK: '无法连接 Pica，请检查网络和代理。不要反复修改密码。',
-            REJECTED:
-                'Pica 拒绝了账号请求，请检查填写信息或在 Pica 客户端确认账号状态。',
-            RATE_LIMIT: 'Pica 请求过于频繁，请稍后再试。',
-            UNAVAILABLE: 'Pica 账号服务暂时不可用，请稍后再试。',
-            RESPONSE:
-                'Pica 账号响应异常，结果尚未确认。请先尝试登录，不要重复注册。'
-        }
-        super(messages[category] ?? messages.RESPONSE)
+        super(accountMessages[category] ?? accountMessages.RESPONSE)
         this.name = 'PicaAccountError'
     }
 }
 
-export function accountHttpError(status?: number) {
-    return new PicaAccountError(
-        !status
-            ? 'NETWORK'
-            : status === 429
-              ? 'RATE_LIMIT'
-              : status >= 500
-                ? 'UNAVAILABLE'
-                : 'REJECTED',
-        status
+function providerSignals(payload: unknown) {
+    if (!payload || typeof payload !== 'object') return { text: '', errorCode: NaN }
+    const value = payload as Record<string, unknown>
+    const nested =
+        value.data && typeof value.data === 'object'
+            ? (value.data as Record<string, unknown>)
+            : {}
+    const parts = [
+        value.error,
+        value.message,
+        value.detail,
+        nested.error,
+        nested.message,
+        nested.detail
+    ]
+        .filter((item) => ['string', 'number'].includes(typeof item))
+        .map(String)
+    const errorCode = Number(value.error ?? nested.error ?? value.code)
+    return { text: parts.join(' ').toLowerCase(), errorCode }
+}
+
+function registrationCategory(payload: unknown): PicaAccountCategory | null {
+    const { text, errorCode } = providerSignals(payload)
+    const username = /(email|user\s*name|username|account)/i.test(text)
+    const invalid = /(validation|invalid|format|length|required|missing|must be)/i.test(
+        text
     )
+    if (
+        username &&
+        /(already|exist|exists|taken|registered|duplicate|duplicated)/i.test(text)
+    )
+        return 'USERNAME_TAKEN'
+    if (/birthday|birth date|date of birth|age/i.test(text))
+        return 'INVALID_BIRTHDAY'
+    if (username && invalid) return 'INVALID_USERNAME'
+    if (/password|passwd/i.test(text) && invalid) return 'INVALID_PASSWORD'
+    if (/(nickname|display name)/i.test(text) && invalid) return 'INVALID_NICKNAME'
+    if (/(question|answer|security|recovery)/i.test(text) && invalid)
+        return 'INVALID_RECOVERY'
+    if (errorCode === 1002 || invalid) return 'VALIDATION'
+    return null
+}
+
+export function accountHttpError(
+    status?: number,
+    payload?: unknown,
+    action: 'login' | 'register' = 'login'
+) {
+    if (!status) return new PicaAccountError('NETWORK')
+    if (status === 429) return new PicaAccountError('RATE_LIMIT', status)
+    if (status >= 500) return new PicaAccountError('UNAVAILABLE', status)
+    if (action === 'register') {
+        const category = registrationCategory(payload)
+        if (category) return new PicaAccountError(category, status)
+        if (status === 409) return new PicaAccountError('USERNAME_TAKEN', status)
+    }
+    return new PicaAccountError('REJECTED', status)
 }

--- a/test/unit/pica-account-onboarding.test.ts
+++ b/test/unit/pica-account-onboarding.test.ts
@@ -27,20 +27,20 @@ describe('Pica registration and account errors', () => {
         expect(value).not.toHaveProperty('confirmPassword')
         expect(value).not.toHaveProperty('acceptedTerms')
     })
-    it('uses the provider-compatible username and password rules for new accounts', () => {
+    it('uses conservative provider-compatible username and password rules for new accounts', () => {
         expect(() =>
             validatePicaRegistration({
                 ...input(),
                 email: 'reader_01.',
-                password: '12345678',
-                confirmPassword: '12345678'
+                password: '123456789',
+                confirmPassword: '123456789'
             })
         ).not.toThrow()
         expect(() =>
             validatePicaRegistration({
                 ...input(),
-                password: '1234567',
-                confirmPassword: '1234567'
+                password: '12345678',
+                confirmPassword: '12345678'
             })
         ).toThrow()
         expect(() =>

--- a/test/unit/pica-account-onboarding.test.ts
+++ b/test/unit/pica-account-onboarding.test.ts
@@ -19,13 +19,36 @@ const input = () => ({
     acceptedTerms: true
 })
 describe('Pica registration and account errors', () => {
-    it('accepts account identifiers without requiring an email and preserves secrets exactly', () => {
+    it('accepts Pica usernames without requiring an email and preserves secrets exactly', () => {
         const value = validatePicaRegistration(input())
         expect(value.email).toBe('example_reader')
         expect(value.password).toBe(' example-password ')
         expect(value.answer1).toBe(' private answer ')
         expect(value).not.toHaveProperty('confirmPassword')
         expect(value).not.toHaveProperty('acceptedTerms')
+    })
+    it('uses the provider-compatible username and password rules for new accounts', () => {
+        expect(() =>
+            validatePicaRegistration({
+                ...input(),
+                email: 'reader_01.',
+                password: '12345678',
+                confirmPassword: '12345678'
+            })
+        ).not.toThrow()
+        expect(() =>
+            validatePicaRegistration({
+                ...input(),
+                password: '1234567',
+                confirmPassword: '1234567'
+            })
+        ).toThrow()
+        expect(() =>
+            validatePicaRegistration({ ...input(), email: 'reader-name' })
+        ).toThrow()
+        expect(() =>
+            validatePicaRegistration({ ...input(), email: '12345678901234567' })
+        ).toThrow()
     })
     it('requires real age, valid date and explicit consent', () => {
         expect(() =>
@@ -88,6 +111,53 @@ describe('Pica registration and account errors', () => {
         expect(await client.register(input())).toEqual({ registered: true })
         expect(calls).toEqual(['auth/register'])
         expect(client.token).toBe('existing-private-session')
+    })
+    it('turns known provider validation responses into actionable safe categories', async () => {
+        const apiAdapter: AxiosAdapter = async (config) => {
+            throw new AxiosError(
+                'provider rejected request',
+                'ERR_BAD_RESPONSE',
+                config,
+                {},
+                {
+                    config,
+                    data: {
+                        code: 400,
+                        error: 1002,
+                        message: 'validation error',
+                        detail: 'birthday must be a valid date string'
+                    },
+                    status: 400,
+                    statusText: 'failure',
+                    headers: new AxiosHeaders()
+                }
+            )
+        }
+        await expect(new Pica({ apiAdapter }).register(input())).rejects.toMatchObject({
+            category: 'INVALID_BIRTHDAY'
+        })
+    })
+    it('recognizes a username collision without surfacing provider body text', async () => {
+        const apiAdapter: AxiosAdapter = async (config) => {
+            throw new AxiosError(
+                'SECRET request',
+                'ERR_BAD_RESPONSE',
+                config,
+                {},
+                {
+                    config,
+                    data: { message: 'email already exists SECRET' },
+                    status: 400,
+                    statusText: 'failure',
+                    headers: new AxiosHeaders()
+                }
+            )
+        }
+        const client = new Pica({ apiAdapter })
+        await expect(client.register(input())).rejects.toMatchObject({
+            category: 'USERNAME_TAKEN'
+        })
+        await expect(client.register(input())).rejects.not.toThrow('SECRET')
     })
     it.each([400, 401, 403, 429, 500])(
         'sanitizes HTTP %s without retrying registration',

--- a/web/account-onboarding.js
+++ b/web/account-onboarding.js
@@ -29,8 +29,8 @@ export function installAccountOnboarding({ post, getDesktop, getLanguage }) {
                 element(
                     'p',
                     text(
-                        '没有账号：可在这里注册第三方 Pica 账号。网络超时请检查代理；注册不等于账号已获评论等额外权限。',
-                        'No account? Register with the third-party Pica service here. For timeouts, check your network/proxy. Registration does not guarantee additional privileges such as commenting.'
+                        '没有账号：可在这里注册第三方 Pica 账号。注册本身不强制使用代理；如果提示无法连接 Pica API，说明当前网络直连失败，请开启系统代理/加速器或配置 HTTP/HTTPS 代理。',
+                        'No account? Register with the third-party Pica service here. Registration does not inherently require a proxy. If the Pica API cannot be reached directly on this network, enable your system proxy/VPN or configure an HTTP/HTTPS proxy.'
                     )
                 )
             )
@@ -107,14 +107,23 @@ export function installAccountOnboarding({ post, getDesktop, getLanguage }) {
             'text',
             50
         )
-        field('email', '新账号标识', 'New account identifier', 'text', 254)
+        fields.name.minLength = 2
+        field(
+            'email',
+            '用户名（1–16 位字母 / 数字 / . / _）',
+            'Username (1–16 letters, digits, . or _)',
+            'text',
+            16
+        )
+        fields.email.pattern = '[A-Za-z0-9._]{1,16}'
         field(
             'password',
-            '密码（至少 9 位）',
-            'Password (at least 9 characters)',
+            '密码（至少 8 位）',
+            'Password (at least 8 characters)',
             'password',
             128
         )
+        fields.password.minLength = 8
         field(
             'confirmPassword',
             '确认密码',
@@ -122,6 +131,7 @@ export function installAccountOnboarding({ post, getDesktop, getLanguage }) {
             'password',
             128
         )
+        fields.confirmPassword.minLength = 8
         field(
             'birthday',
             '真实出生日期（须年满 18 岁）',
@@ -212,18 +222,28 @@ export function installAccountOnboarding({ post, getDesktop, getLanguage }) {
                     )
                 document.getElementById(`${prefix}-account`).value =
                     payload.email
-                document.getElementById(`${prefix}-password`).value =
-                    payload.password
                 message.textContent = text(
-                    '注册成功。返回登录后测试连接并保存；注册不会自动同步或下载。',
-                    'Registered. Return to login, test and save. No automatic sync or download was started.'
+                    '注册成功。用户名已带回登录表单；请自行输入刚才设置的密码，测试连接并保存。',
+                    'Registered. The username was copied back to the login form; enter the password you just created, test the connection, and save.'
                 )
                 for (const input of Object.values(fields)) input.value = ''
+                accepted.checked = false
             } catch (error) {
-                message.textContent = `${error.message} ${text('若连接中断，账号可能已创建，请先返回尝试登录。', 'If the connection was interrupted, the account may already exist. Try logging in first.')}`
+                const reason = error instanceof Error ? error.message : String(error)
+                message.textContent = `${text('注册失败：', 'Registration failed: ')}${reason}`
+                const uncertain = /无法连接 Pica API|响应异常|尚未确认|not confirmed|network|timeout/i.test(reason)
+                if (!uncertain) {
+                    submitted = false
+                    submit.disabled = false
+                } else {
+                    message.textContent += text(
+                        ' 本次结果可能无法确认，请先返回登录尝试，不要立即重复注册。',
+                        ' The result may be uncertain; try logging in before registering again.'
+                    )
+                }
             } finally {
                 close.disabled = false
-                // Deliberate one-shot form: a timed-out registration may have succeeded.
+                // Registration values stay only in the live form; the request copy is erased.
                 for (const key of Object.keys(payload)) delete payload[key]
             }
         }

--- a/web/account-onboarding.js
+++ b/web/account-onboarding.js
@@ -118,12 +118,12 @@ export function installAccountOnboarding({ post, getDesktop, getLanguage }) {
         fields.email.pattern = '[A-Za-z0-9._]{1,16}'
         field(
             'password',
-            '密码（至少 8 位）',
-            'Password (at least 8 characters)',
+            '密码（至少 9 位）',
+            'Password (at least 9 characters)',
             'password',
             128
         )
-        fields.password.minLength = 8
+        fields.password.minLength = 9
         field(
             'confirmPassword',
             '确认密码',
@@ -131,7 +131,7 @@ export function installAccountOnboarding({ post, getDesktop, getLanguage }) {
             'password',
             128
         )
-        fields.confirmPassword.minLength = 8
+        fields.confirmPassword.minLength = 9
         field(
             'birthday',
             '真实出生日期（须年满 18 岁）',


### PR DESCRIPTION
## Summary
- align new-account username validation with current open-source Pica clients: 1–16 characters using letters, digits, `.` or `_`
- keep the stricter 9-character password minimum because current open-source references disagree (some UIs allow 8, while current API documentation says greater than 8)
- distinguish safe registration failure categories on Desktop without exposing arbitrary provider response bodies
- explain that proxy/VPN use is network-dependent rather than a protocol requirement
- preserve Android registration form values after confirmed failures and avoid immediate duplicate retries when the outcome is uncertain
- update Desktop registration copy and retry behavior
- add regression coverage for username/password rules, provider validation failures, collisions, and transport failures

## Network conclusion
Registration still targets `https://picaapi.picacomic.com/`. A proxy is not inherently required by the registration protocol, but direct reachability is network/ISP dependent. This change does not route registration credentials through community reverse-proxy domains.

## Platform behavior
- Desktop: provider response data is used only for an allowlisted error classification (for example username collision or birthday validation); arbitrary provider text is never surfaced.
- Android: the current native transport intentionally discards provider response bodies for account requests, so this PR does not claim field-level provider diagnostics there. It improves local validation, network/rate/server/rejection feedback, uncertain-result handling, and form preservation without weakening that boundary.

## Validation
CI covers Web/Desktop typecheck, web syntax, unit/integration tests and build, plus Android unit tests, lint and release assembly. Real third-party registration should still be manually smoke-tested with a disposable test account before this draft is merged.